### PR TITLE
Include `poison` in the applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Nadia.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:httpoison]]
+    [applications: [:httpoison, :poison]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
In order to enable this library to be included in projects deploying
via `exrm`, production dependencies (`poison` in this case) need
to be added to the applications list in the `mix.exs` file.

Closes #24 