### PR TITLE
Add environment variable checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ config :nadia,
   recv_timeout: 10
 ```
 
+Environment variables may be used as well:
+
+```elixir
+config :nadia,
+  token: {:system, "ENVVAR_WITH_MYAPP_TOKEN", "default_value_if_needed"}
+```
+
 And then, in `mix.exs`, list `:nadia` as an application inside `application/0`:
 
 ```elixir

--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -8,8 +8,21 @@ defmodule Nadia.API do
   @default_timeout 5
   @base_url "https://api.telegram.org/bot"
 
-  defp token, do: Application.get_env(:nadia, :token)
-  defp recv_timeout, do: Application.get_env(:nadia, :recv_timeout, @default_timeout)
+  defp token, do: config_or_env(:token)
+  defp recv_timeout, do: config_or_env(:recv_timeout) || @default_timeout
+
+  defp config_or_env(key) do
+    case Application.fetch_env(:nadia, key) do
+      {:ok, {:system, var}} -> System.get_env(var)
+      {:ok, {:system, var, default}} ->
+        case System.get_env(var) do
+          nil -> default
+          val -> val
+        end
+      {:ok, value} -> value
+      :error -> nil
+    end
+  end
 
   defp build_url(method), do: @base_url <> token() <> "/" <> method
 


### PR DESCRIPTION
Instead of just using a given value, this commit adds the ability to use
a environment variable instead. It uses the following syntax in
`config.exs`:

        config :nadia, :token, {:system, "ENV_VAR_NAME", "default value"}

It is possible to define a default value as well. The old API still
works, it just adds a way to use env vars as well.