### PR TITLE
Add {:process, key} option to configure the token in the process dict

### DIFF
--- a/lib/nadia.ex
+++ b/lib/nadia.ex
@@ -401,12 +401,12 @@ defmodule Nadia do
       iex> Nadia.get_file_link(%Nadia.Model.File{file_id: "BQADBQADBgADmEjsA1aqdSxtzvvVAg",
       ...> file_path: "document/file_10", file_size: 17680})
       {:ok,
-      "https://api.telegram.org/file/bot#{Application.get_env(:nadia, :token)}/document/file_10"}
+      "https://api.telegram.org/file/bot#{Nadia.API.token()}/document/file_10"}
 
   """
   @spec get_file_link(File.t) :: {:ok, binary} | {:error, Error.t}
   def get_file_link(file) do
-    token = Application.get_env(:nadia, :token)
+    token = Nadia.API.token()
     {:ok, @base_file_url <> token <> "/" <> file.file_path}
   end
 
@@ -512,7 +512,7 @@ defmodule Nadia do
   def get_chat_member(chat_id, user_id) do
     request("getChatMember", chat_id: chat_id, user_id: user_id)
   end
-  
+
   @doc """
   Use this method to send answers to callback queries sent from inline keyboards.
   The answer will be displayed to the user as a notification at the top of the chat

--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -8,7 +8,7 @@ defmodule Nadia.API do
   @default_timeout 5
   @base_url "https://api.telegram.org/bot"
 
-  defp token, do: config_or_env(:token)
+  def token, do: config_or_env(:token)
   defp recv_timeout, do: config_or_env(:recv_timeout) || @default_timeout
 
   defp config_or_env(key) do

--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -13,6 +13,7 @@ defmodule Nadia.API do
 
   defp config_or_env(key) do
     case Application.fetch_env(:nadia, key) do
+      {:ok, {:process, key}} -> Process.get(key)
       {:ok, {:system, var}} -> System.get_env(var)
       {:ok, {:system, var, default}} ->
         case System.get_env(var) do


### PR DESCRIPTION
As a simpler solution for #22 and #23, I did a 1-minute hack to retrieve the bot's token from the process dictionary.This allows you to do the following:

```elixir
config :nadia,
  token: {:process, :some_key}
```

And the in the Elixir process you use `Process.put(:some_key, your_token)` once, and then use the Nadia calls as usual.

This suits my use case very well as I have one Elixir process per telegram bot.  But it's a bit controversial as well to (ab)use the pdict in this way...