### PR TITLE
Add match InlineQuery in response from telegram

### DIFF
--- a/lib/nadia/parser.ex
+++ b/lib/nadia/parser.ex
@@ -12,7 +12,9 @@ defmodule Nadia.Parser do
     PhotoSize,
     Audio,
     Document,
-    Sticker
+    Sticker,
+    InlineQuery,
+    ChosenInlineResult
   }
 
   alias Nadia.Model.{Video, Voice, Contact, Location, Venue, Update, File, CallbackQuery}
@@ -20,7 +22,6 @@ defmodule Nadia.Parser do
 
   @doc """
   parse `result` field of decoded API response json.
-
   Args:
   * `result` - `result` field of decoded API response json
   * `method` - name of API method
@@ -42,6 +43,9 @@ defmodule Nadia.Parser do
   end
 
   @keys_of_message [:message, :reply_to_message, :channel_post]
+  @keys_of_inline_query [:inline_query]
+  @keys_of_callback_query [:callback_query]
+  @keys_of_choosen_inline_result [:chosen_inline_result]
   @keys_of_photo [:photo, :new_chat_photo]
   @keys_of_user [:from, :forward_from, :new_chat_participant, :left_chat_participant]
 
@@ -66,5 +70,11 @@ defmodule Nadia.Parser do
   defp parse({key, val}) when key in @keys_of_photo, do: {key, parse(:photo, val)}
   defp parse({key, val}) when key in @keys_of_user, do: {key, parse(User, val)}
   defp parse({key, val}) when key in @keys_of_message, do: {key, parse(Message, val)}
+  defp parse({key, val}) when key in @keys_of_inline_query, do: {key, parse(InlineQuery, val)}
+  defp parse({key, val}) when key in @keys_of_callback_query, do: {key, parse(CallbackQuery, val)}
+
+  defp parse({key, val}) when key in @keys_of_choosen_inline_result,
+    do: {key, parse(ChosenInlineResult, val)}
+
   defp parse(others), do: others
 end

--- a/test/nadia/parser_test.exs
+++ b/test/nadia/parser_test.exs
@@ -2,7 +2,17 @@ defmodule Nadia.ParserTest do
   use ExUnit.Case, async: true
 
   alias Nadia.Parser
-  alias Nadia.Model.{User, PhotoSize, UserProfilePhotos}
+
+  alias Nadia.Model.{
+    Update,
+    InlineQuery,
+    CallbackQuery,
+    ChosenInlineResult,
+    User,
+    PhotoSize,
+    UserProfilePhotos,
+    Message
+  }
 
   test "parse result of get_me" do
     me =
@@ -119,6 +129,116 @@ defmodule Nadia.ParserTest do
                  text: "Test"
                },
                update_id: 790_000_001
+             }
+           ]
+  end
+
+  test "parse result of get_updates inline query" do
+    inline_query =
+      Parser.parse_result(
+        [
+          %{
+            inline_query: %{
+              id: 111,
+              from: %{
+                id: 222,
+                username: "Rastopyr",
+                first_name: "Roman",
+                last_name: "Senin"
+              },
+              location: %{
+                latitude: 123,
+                longitude: 321
+              },
+              offset: 0,
+              query: "/new-feature"
+            }
+          }
+        ],
+        "getUpdates"
+      )
+
+    assert inline_query == [
+             %Update{
+               inline_query: %InlineQuery{
+                 id: 111,
+                 from: %Nadia.Model.User{
+                   id: 222,
+                   first_name: "Roman",
+                   last_name: "Senin",
+                   username: "Rastopyr"
+                 },
+                 location: %Nadia.Model.Location{
+                   latitude: 123,
+                   longitude: 321
+                 },
+                 offset: 0,
+                 query: "/new-feature"
+               }
+             }
+           ]
+  end
+
+  test "parse result of get_updates callback query" do
+    callback_query =
+      Parser.parse_result(
+        [
+          %{
+            callback_query: %{
+              id: 111,
+              data: "111",
+              inline_message_id: "111",
+              message: %{
+                text: "Hello world"
+              }
+            }
+          }
+        ],
+        "getUpdates"
+      )
+
+    assert callback_query == [
+             %Update{
+               callback_query: %CallbackQuery{
+                 id: 111,
+                 data: "111",
+                 inline_message_id: "111",
+                 message: %Message{
+                   text: "Hello world"
+                 }
+               }
+             }
+           ]
+  end
+
+  test "parse result of get_updates chosen inline result" do
+    chosen_inline_result =
+      Parser.parse_result(
+        [
+          %{
+            chosen_inline_result: %{
+              result_id: 111,
+              from: %{
+                id: 111,
+                first_name: "Roman"
+              },
+              query: "42"
+            }
+          }
+        ],
+        "getUpdates"
+      )
+
+    assert chosen_inline_result == [
+             %Update{
+               chosen_inline_result: %ChosenInlineResult{
+                 result_id: 111,
+                 from: %User{
+                   id: 111,
+                   first_name: "Roman"
+                 },
+                 query: "42"
+               }
              }
            ]
   end


### PR DESCRIPTION
## Motivation

When i match response from `Nadia.get_updates` response i can match by `%Message`, but can't by `%InlineQuery`. Example:
```elixir
def get_chat_id(response) do
  case response do
    %Nadia.Model.InlineQuery{ from: from } -> # will not match, because `inline_query` not convert to struct
      from.id
    %Nadia.Model.Message{ chat: %Nadia.Model.Chat{ id: id } } -> # will match, because `message` convert to struct
      id
    _ -> raise "No chat id found!"
  end
end
```

## Proposal

Add  all types for convert to struct:

- [x] `%Message`
- [x] `%InlineQuery`
- [x] `%CallbackQuery`
- [x] `%ChosenInlineResult`
