### PR TITLE
Fix poison decode crash

### DIFF
--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -32,13 +32,14 @@ defmodule Nadia.API do
       {:ok, result} -> {:ok, Nadia.Parser.parse_result(result, method)}
       %{ok: false, description: description} -> {:error, %Error{reason: description}}
       {:error, %HTTPoison.Error{reason: reason}} -> {:error, %Error{reason: reason}}
+      {:error, error} -> {:error, %Error{reason: error}}
     end
   end
 
   defp decode_response(response) do
     with {:ok, %HTTPoison.Response{body: body}} <- response,
-          %{result: result} <- Poison.decode!(body, keys: :atoms),
-      do: {:ok, result}
+         {:ok, %{result: result}} <- Poison.decode(body, keys: :atoms),
+         do: {:ok, result}
   end
 
   defp build_multipart_request(params, file_field) do


### PR DESCRIPTION
Changed poison `decode!` to `decode`, in order to be able to handle
cases where telegram API will return an HTML/XML instead of JSON
probably due to some error that happened on their side.

This is needed so that client applications dont break when this happens.

Closes https://github.com/zhyu/nadia/issues/56