### PR TITLE
Setup travis.yaml to check tests and format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
     - deps
 script:
   - mix test || travis_terminate 1
-  - mix format --check-formatted || travis_treminate 1
+  - mix format --check-formatted || travis_terminate 1
 after_script:
   - MIX_ENV=docs mix do deps.get, inch.report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.2.0
+  - 1.6.0
 otp_release:
-  - 18.0
+  - 20.2
+cache:
+  directories:
+    - _build
+    - deps
+script:
+  - mix test || travis_terminate 1
+  - mix format --check-formatted || travis_treminate 1
 after_script:
   - MIX_ENV=docs mix do deps.get, inch.report

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Nadia.Mixfile do
     [
       app: :nadia,
       version: "0.4.2",
-      elixir: "~> 1.2",
+      elixir: "~> 1.6",
       description: "Telegram Bot API Wrapper written in Elixir",
       package: package(),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
The good news:
- Travis will require to pass the tests
- Travis will require the format

The bad news:
Because the format are on elixir 1.6, we need to setup the travis.yml to use that version.

I changed the mix.exs vesion too, to ensure that there are no incompatibilities, but maybe you want to let the mix.exs version at 1.2 and pass the tests & format on 1.6.