### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ config :nadia,
 ```
 
 And then, in `mix.exs`, list `:nadia` as an application inside `application/0`:
-
+(you can omit this if your elixir is >= 1.4)
 ```elixir
 def application do
   [applications: [:nadia]]


### PR DESCRIPTION
from [elixir 1.4 documentation](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/), Mix v1.4 now automatically infers your applications list as long as you leave the `:applications` key empty. So we should put an explanation for people who use more than version 1.4. Everything works well.