### PR TITLE
Fix `Nadia.get_file_link` function when token is inserted through envs

### DIFF
--- a/lib/nadia.ex
+++ b/lib/nadia.ex
@@ -12,8 +12,6 @@ defmodule Nadia do
 
   @behaviour Nadia.Behaviour
 
-  @base_file_url "https://api.telegram.org/file/bot"
-
   @doc """
   A simple method for testing your bot's auth token. Requires no parameters.
   Returns basic information about the bot in form of a User object.
@@ -422,13 +420,12 @@ defmodule Nadia do
       iex> Nadia.get_file_link(%Nadia.Model.File{file_id: "BQADBQADBgADmEjsA1aqdSxtzvvVAg",
       ...> file_path: "document/file_10", file_size: 17680})
       {:ok,
-      "https://api.telegram.org/file/bot#{Application.get_env(:nadia, :token)}/document/file_10"}
+      "https://api.telegram.org/file/bot#{Nadia.Config.token()}/document/file_10"}
 
   """
   @spec get_file_link(File.t()) :: {:ok, binary} | {:error, Error.t()}
   def get_file_link(file) do
-    token = Application.get_env(:nadia, :token)
-    {:ok, @base_file_url <> token <> "/" <> file.file_path}
+    {:ok, build_file_url(file.file_path)}
   end
 
   @doc """

--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -124,4 +124,15 @@ defmodule Nadia.API do
     {_, response} = request(method, options, file_field)
     response
   end
+
+  @doc ~S"""
+  Use this function to build file url.
+
+  iex> Nadia.API.build_file_url("document/file_10")
+  "https://api.telegram.org/file/bot#{Nadia.Config.token()}/document/file_10"
+  """
+  @spec build_file_url(binary) :: binary
+  def build_file_url(file_path) do
+    Config.file_base_url() <> Config.token() <> "/" <> file_path
+  end
 end

--- a/lib/nadia/config.ex
+++ b/lib/nadia/config.ex
@@ -2,6 +2,7 @@ defmodule Nadia.Config do
   @default_timeout 5
   @default_base_url "https://api.telegram.org/bot"
   @default_graph_base_url "https://api.telegra.ph"
+  @default_file_base_url "https://api.telegram.org/file/bot"
 
   def token, do: config_or_env(:token)
   def proxy, do: config_or_env(:proxy)
@@ -11,6 +12,7 @@ defmodule Nadia.Config do
   def recv_timeout, do: config_or_env(:recv_timeout) || @default_timeout
   def base_url, do: config_or_env(:base_url) || @default_base_url
   def graph_base_url, do: config_or_env(:graph_base_url) || @default_graph_base_url
+  def file_base_url, do: config_or_env(:file_base_url) || @default_file_base_url
 
   defp config_or_env(key) do
     case Application.fetch_env(:nadia, key) do

--- a/test/nadia/api_test.exs
+++ b/test/nadia/api_test.exs
@@ -2,6 +2,7 @@ defmodule Nadia.APITest do
   use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
   doctest Nadia.API
+  alias Nadia.API
 
   setup_all do
     unless Application.get_env(:nadia, :token) do
@@ -20,5 +21,10 @@ defmodule Nadia.APITest do
     use_cassette "api_request_with_map", match_requests_on: [:request_body] do
       assert [] == Nadia.API.request?("getUpdates", %{"limit" => 4})
     end
+  end
+
+  test "build_file_url" do
+    assert API.build_file_url("document/file_10") ==
+             "https://api.telegram.org/file/bot#{Nadia.Config.token()}/document/file_10"
   end
 end

--- a/test/nadia/config_test.exs
+++ b/test/nadia/config_test.exs
@@ -13,10 +13,12 @@ defmodule Nadia.ConfigTest do
   setup do
     base_url = Application.get_env(:nadia, :base_url)
     graph_base_url = Application.get_env(:nadia, :graph_base_url)
+    file_base_url = Application.get_env(:nadia, :file_base_url)
 
     on_exit(fn ->
       restore_env!(:base_url, base_url)
       restore_env!(:graph_base_url, graph_base_url)
+      restore_env!(:file_base_url, file_base_url)
     end)
   end
 
@@ -100,5 +102,37 @@ defmodule Nadia.ConfigTest do
     :ok = Application.delete_env(:nadia, :graph_base_url)
 
     assert Config.graph_base_url() == "https://api.telegra.ph"
+  end
+
+  test "Config.file_base_url/0 returns config value when present" do
+    :ok = Application.put_env(:nadia, :file_base_url, "http://foobar.com/api")
+
+    assert Config.file_base_url() == "http://foobar.com/api"
+  end
+
+  test "Config.file_base_url/0 returns environment variable" do
+    :ok = Application.put_env(:nadia, :file_base_url, {:system, "FILE_BASE_URL"})
+    :ok = System.put_env("FILE_BASE_URL", "http://somethingelse.com/api")
+
+    assert Config.file_base_url() == "http://somethingelse.com/api"
+  end
+
+  test "Config.file_base_url/0 returns environment variable default" do
+    :ok =
+      Application.put_env(
+        :nadia,
+        :file_base_url,
+        {:system, "FILE_BASE_URL", "http://somedefault.com/api"}
+      )
+
+    :ok = System.delete_env("FILE_BASE_URL")
+
+    assert Config.file_base_url() == "http://somedefault.com/api"
+  end
+
+  test "Config.file_base_url/0 returns default when unset" do
+    :ok = Application.delete_env(:nadia, :file_base_url)
+
+    assert Config.file_base_url() == "https://api.telegram.org/file/bot"
   end
 end

--- a/test/nadia_test.exs
+++ b/test/nadia_test.exs
@@ -6,7 +6,7 @@ defmodule NadiaTest do
 
   setup_all do
     unless Application.get_env(:nadia, :token) do
-      Application.put_env(:nadia, :token, "TEST_TOKEN")
+      Application.put_env(:nadia, :token, {:system, "ENV_TOKEN", "TEST_TOKEN"})
     end
 
     :ok
@@ -127,6 +127,19 @@ defmodule NadiaTest do
       refute is_nil(file.file_path)
       assert file.file_id == "BQADBQADBgADmEjsA1aqdSxtzvvVAg"
     end
+  end
+
+  test "get_file_link" do
+    file = %Nadia.Model.File{
+      file_id: "BQADBQADBgADmEjsA1aqdSxtzvvVAg",
+      file_path: "document/file_10",
+      file_size: 17680
+    }
+
+    {:ok, file_link} = Nadia.get_file_link(file)
+
+    assert file_link ==
+             "https://api.telegram.org/file/bot#{Nadia.Config.token()}/document/file_10"
   end
 
   test "get_chat" do


### PR DESCRIPTION
Hello,

I fixed the ```Nadia.get_file_link``` function when token is inserted through envs. 
I used the ```Nadia.Config.token``` function instead of ```Application.get_env(:nadia, :token)```. Does that make sense to you?

Thanks.