### PR TITLE
Fixed spec for function Nadia.edit_message_text

### DIFF
--- a/lib/nadia.ex
+++ b/lib/nadia.ex
@@ -588,7 +588,7 @@ defmodule Nadia do
   * `:reply_markup`	- A JSON-serialized object for an inline
   keyboard - `Nadia.Model.InlineKeyboardMarkup`
   """
-  @spec edit_message_text(integer | binary, integer, binary, [{atom, any}]) ::
+  @spec edit_message_text(integer | binary, integer, binary, binary, [{atom, any}]) ::
           {:ok, Message.t()} | {:error, Error.t()}
   def edit_message_text(chat_id, message_id, inline_message_id, text, options \\ []) do
     request(


### PR DESCRIPTION
Fixed the type spec for the edit_message_text function to include the type 'binary' for the parameter 'text'.

Note: This is my first time contributing to a open source project, let me know if I have made a mistake in the pull request process.  Thank you.