### PR TITLE
Fixing Nadia.Behaviour.

### DIFF
--- a/lib/nadia/behaviour.ex
+++ b/lib/nadia/behaviour.ex
@@ -36,7 +36,7 @@ defmodule Nadia.Behaviour do
   @callback get_chat_member(integer | binary, integer) ::
               {:ok, ChatMember.t()} | {:error, Error.t()}
   @callback answer_callback_query(binary, [{atom, any}]) :: :ok | {:error, Error.t()}
-  @callback edit_message_text(integer | binary, integer, binary, [{atom, any}]) ::
+  @callback edit_message_text(integer | binary, integer, binary, binary, [{atom, any}]) ::
               {:ok, Message.t()} | {:error, Error.t()}
   @callback edit_message_caption(integer | binary, integer, binary, [{atom, any}]) ::
               {:ok, Message.t()} | {:error, Error.t()}


### PR DESCRIPTION
Based on a current `Nadia.Behaviour` we have:
```elixir
@callback edit_message_text(integer | binary, integer, binary, [{atom, any}]) :: {:ok, Message.t()} | {:error, Error.t()}
```

But actually in code we have
```elixir
@spec edit_message_text(integer | binary, integer, binary, binary, [{atom, any}]) :: {:ok, Message.t()} | {:error, Error.t()}
  def edit_message_text(chat_id, message_id, inline_message_id, text, options \\ [])
```

Seems related to #67 spec was fixed, but not a behaviour.  
Btw #67 can be closed due to specs have been fixed.