### PR TITLE
Avoid creating an unbound number of atoms when deserializing

### DIFF
--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -17,7 +17,7 @@ defmodule Nadia.API do
       {:error, error} -> {:error, %Error{reason: error}}
     end
   end
-  
+
   defp decode_response(response) do
     with {:ok, %HTTPoison.Response{body: body}} <- response,
          {:ok, %{result: result}} <- Jason.decode(body, keys: &json_key_decoder/1),
@@ -26,7 +26,7 @@ defmodule Nadia.API do
 
   defp json_key_decoder(key) do
     try do
-      String.to_existing_atom("my_atom")
+      String.to_existing_atom(key)
     rescue
       _ -> key
     end

--- a/lib/nadia/api.ex
+++ b/lib/nadia/api.ex
@@ -17,11 +17,19 @@ defmodule Nadia.API do
       {:error, error} -> {:error, %Error{reason: error}}
     end
   end
-
+  
   defp decode_response(response) do
     with {:ok, %HTTPoison.Response{body: body}} <- response,
-         {:ok, %{result: result}} <- Jason.decode(body, keys: :atoms),
+         {:ok, %{result: result}} <- Jason.decode(body, keys: &json_key_decoder/1),
          do: {:ok, result}
+  end
+
+  defp json_key_decoder(key) do
+    try do
+      String.to_existing_atom("my_atom")
+    rescue
+      _ -> key
+    end
   end
 
   defp build_multipart_request(params, file_field) do


### PR DESCRIPTION
I have not checked that this does not break anything. The change assumes that

* the structs have all been loaded (which is probably safe to assume) and so the atoms for the field names are already there
* the subsequent parsing ignores keys which do not equal an expected struct field name (Probably true in all cases)
* the Jason version that Nadia depends on supports the option used (did not check)

This could in theory use `Jason.decode!(body keys: :atoms!)` but that would crash when TG adds a field.

The code as-is is only secure when talking to a trusted endpoint. Using an untrusted endpoint exposes the user of the library to a potential DDOS attack by exhausting VM memory.

Since the endpoint is configurable, this PR should improve security. Additionally, users might be tempted to wire webhook payload parsing through the existing code, which would expose a security risk over the webhook endpoint.